### PR TITLE
Drop 1.6 and bump to 1.10 LTS

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - '1.10'
           - 'nightly'
           - '1'
         os:


### PR DESCRIPTION
We are dropping 1.6 LTS in favor of 1.10 being the new Julia LTS.